### PR TITLE
Add predios and lotes features and UI

### DIFF
--- a/mobile_app/lib/features/home/presentation/pages/dashboard_placeholder_page.dart
+++ b/mobile_app/lib/features/home/presentation/pages/dashboard_placeholder_page.dart
@@ -116,6 +116,25 @@ class _DashboardPlaceholderPageState extends State<DashboardPlaceholderPage> {
                 SizedBox(
                   width: double.infinity,
                   height: 52,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      Navigator.pushNamed(context, '/predios');
+                    },
+                    style: ElevatedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                    ),
+                    child: const Text(
+                      'Gestionar predios',
+                      style: TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  height: 52,
                   child: ElevatedButton.icon(
                     onPressed: _isLoggingOut ? null : _logout,
                     icon: const Icon(Icons.logout),

--- a/mobile_app/lib/features/lotes/data/repositories/lotes_repository.dart
+++ b/mobile_app/lib/features/lotes/data/repositories/lotes_repository.dart
@@ -1,0 +1,42 @@
+import '../../domain/models/lote.dart';
+import '../services/lotes_service.dart';
+
+class LotesRepository {
+  final LotesService _service;
+
+  LotesRepository({LotesService? service})
+      : _service = service ?? LotesService();
+
+  Future<void> createLote(Lote lote) {
+    return _service.createLote(lote);
+  }
+
+  Future<List<Lote>> getLotesByPredio({
+    required String predioId,
+    required String productorId,
+  }) {
+    return _service.getLotesByPredio(
+      predioId: predioId,
+      productorId: productorId,
+    );
+  }
+
+  Future<Lote?> getLoteById(String loteId) {
+    return _service.getLoteById(loteId);
+  }
+
+  Future<void> updateLote(Lote lote) {
+    return _service.updateLote(lote);
+  }
+
+
+  Future<void> updateEstadoLote({
+  required String loteId,
+  required String estadoLote,
+}) {
+  return _service.updateEstadoLote(
+    loteId: loteId,
+    estadoLote: estadoLote,
+  );
+}
+}

--- a/mobile_app/lib/features/lotes/data/services/lotes_service.dart
+++ b/mobile_app/lib/features/lotes/data/services/lotes_service.dart
@@ -1,0 +1,73 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../domain/models/lote.dart';
+
+class LotesService {
+  final FirebaseFirestore _firestore;
+
+  LotesService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  Future<void> createLote(Lote lote) async {
+    final docRef = _firestore.collection('lotes').doc();
+
+    await docRef.set({
+      'loteId': docRef.id,
+      'predioId': lote.predioId,
+      'productorId': lote.productorId,
+      'nombreLote': lote.nombreLote,
+      'codigoLote': lote.codigoLote,
+      'areaHectareas': lote.areaHectareas,
+      'especieVegetalActual': lote.especieVegetalActual,
+      'variedadActual': lote.variedadActual,
+      'estadoLote': lote.estadoLote,
+      'observaciones': lote.observaciones,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Future<List<Lote>> getLotesByPredio({
+    required String predioId,
+    required String productorId,
+  }) async {
+    final snapshot = await _firestore
+        .collection('lotes')
+        .where('predioId', isEqualTo: predioId)
+        .where('productorId', isEqualTo: productorId)
+        .get();
+
+    return snapshot.docs.map((doc) => Lote.fromMap(doc.data())).toList();
+  }
+
+  Future<Lote?> getLoteById(String loteId) async {
+    final doc = await _firestore.collection('lotes').doc(loteId).get();
+
+    if (!doc.exists || doc.data() == null) {
+      return null;
+    }
+
+    return Lote.fromMap(doc.data()!);
+  }
+
+  Future<void> updateLote(Lote lote) async {
+    await _firestore.collection('lotes').doc(lote.loteId).update({
+      'nombreLote': lote.nombreLote,
+      'codigoLote': lote.codigoLote,
+      'areaHectareas': lote.areaHectareas,
+      'especieVegetalActual': lote.especieVegetalActual,
+      'variedadActual': lote.variedadActual,
+      'observaciones': lote.observaciones,
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Future<void> updateEstadoLote({
+  required String loteId,
+  required String estadoLote,
+}) async {
+  await _firestore.collection('lotes').doc(loteId).update({
+    'estadoLote': estadoLote,
+    'updatedAt': FieldValue.serverTimestamp(),
+  });
+}
+}

--- a/mobile_app/lib/features/lotes/domain/models/lote.dart
+++ b/mobile_app/lib/features/lotes/domain/models/lote.dart
@@ -1,0 +1,68 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Lote {
+  final String loteId;
+  final String predioId;
+  final String productorId;
+
+  final String nombreLote;
+  final String? codigoLote;
+  final double areaHectareas;
+
+  final String especieVegetalActual;
+  final String? variedadActual;
+  final String estadoLote;
+  final String? observaciones;
+
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  Lote({
+    required this.loteId,
+    required this.predioId,
+    required this.productorId,
+    required this.nombreLote,
+    this.codigoLote,
+    required this.areaHectareas,
+    required this.especieVegetalActual,
+    this.variedadActual,
+    required this.estadoLote,
+    this.observaciones,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'loteId': loteId,
+      'predioId': predioId,
+      'productorId': productorId,
+      'nombreLote': nombreLote,
+      'codigoLote': codigoLote,
+      'areaHectareas': areaHectareas,
+      'especieVegetalActual': especieVegetalActual,
+      'variedadActual': variedadActual,
+      'estadoLote': estadoLote,
+      'observaciones': observaciones,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  factory Lote.fromMap(Map<String, dynamic> map) {
+    return Lote(
+      loteId: map['loteId'] ?? '',
+      predioId: map['predioId'] ?? '',
+      productorId: map['productorId'] ?? '',
+      nombreLote: map['nombreLote'] ?? '',
+      codigoLote: map['codigoLote'],
+      areaHectareas: (map['areaHectareas'] as num?)?.toDouble() ?? 0,
+      especieVegetalActual: map['especieVegetalActual'] ?? '',
+      variedadActual: map['variedadActual'],
+      estadoLote: map['estadoLote'] ?? 'ACTIVO',
+      observaciones: map['observaciones'],
+      createdAt: (map['createdAt'] as Timestamp?)?.toDate(),
+      updatedAt: (map['updatedAt'] as Timestamp?)?.toDate(),
+    );
+  }
+}

--- a/mobile_app/lib/features/lotes/presentation/pages/lote_create_page.dart
+++ b/mobile_app/lib/features/lotes/presentation/pages/lote_create_page.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import '../../../predios/domain/models/predio.dart';
+import '../../data/repositories/lotes_repository.dart';
+import '../../domain/models/lote.dart';
+import '../widgets/lote_form.dart';
+
+class LoteCreatePage extends StatefulWidget {
+  const LoteCreatePage({super.key});
+
+  @override
+  State<LoteCreatePage> createState() => _LoteCreatePageState();
+}
+
+class _LoteCreatePageState extends State<LoteCreatePage> {
+  final _formKey = GlobalKey<FormState>();
+  final _repository = LotesRepository();
+
+  final _nombreController = TextEditingController();
+  final _codigoController = TextEditingController();
+  final _areaController = TextEditingController();
+  final _especieController = TextEditingController();
+  final _variedadController = TextEditingController();
+  final _observacionesController = TextEditingController();
+
+  bool _isSaving = false;
+  Predio? _predio;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args is Predio) {
+      _predio = args;
+    }
+  }
+
+  @override
+  void dispose() {
+    _nombreController.dispose();
+    _codigoController.dispose();
+    _areaController.dispose();
+    _especieController.dispose();
+    _variedadController.dispose();
+    _observacionesController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveLote() async {
+    if (!_formKey.currentState!.validate() || _predio == null) return;
+
+    setState(() => _isSaving = true);
+
+    try {
+      final area = double.parse(_areaController.text.trim().replaceAll(',', '.'));
+
+      final lote = Lote(
+        loteId: '',
+        predioId: _predio!.predioId,
+        productorId: _predio!.productorId,
+        nombreLote: _nombreController.text.trim(),
+        codigoLote: _codigoController.text.trim().isEmpty
+            ? null
+            : _codigoController.text.trim(),
+        areaHectareas: area,
+        especieVegetalActual: _especieController.text.trim(),
+        variedadActual: _variedadController.text.trim().isEmpty
+            ? null
+            : _variedadController.text.trim(),
+        estadoLote: 'ACTIVO',
+        observaciones: _observacionesController.text.trim().isEmpty
+            ? null
+            : _observacionesController.text.trim(),
+        createdAt: null,
+        updatedAt: null,
+      );
+
+      await _repository.createLote(lote);
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Lote creado correctamente')),
+      );
+
+      Navigator.pop(context, true);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('No fue posible crear el lote: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const bg = Color(0xFFF7F9F5);
+
+    if (_predio == null) {
+      return Scaffold(
+        backgroundColor: bg,
+        appBar: AppBar(title: const Text('Crear lote')),
+        body: const Center(
+          child: Text('No se recibió el predio seleccionado'),
+        ),
+      );
+    }
+
+    return Scaffold(
+      backgroundColor: bg,
+      appBar: AppBar(
+        title: const Text('Crear lote'),
+      ),
+      body: LoteForm(
+        formKey: _formKey,
+        nombreController: _nombreController,
+        codigoController: _codigoController,
+        areaController: _areaController,
+        especieController: _especieController,
+        variedadController: _variedadController,
+        observacionesController: _observacionesController,
+        isSaving: _isSaving,
+        onSubmit: _saveLote,
+        submitLabel: 'Guardar lote',
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/lotes/presentation/pages/lote_detail_page.dart
+++ b/mobile_app/lib/features/lotes/presentation/pages/lote_detail_page.dart
@@ -1,0 +1,496 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/features/lotes/data/repositories/lotes_repository.dart';
+import '../../domain/models/lote.dart';
+
+class LoteDetailPage extends StatefulWidget {
+  const LoteDetailPage({super.key});
+
+  @override
+  State<LoteDetailPage> createState() => _LoteDetailPageState();
+}
+
+class _LoteDetailPageState extends State<LoteDetailPage> {
+  Lote? _lote;
+
+   bool _wasUpdated = false;
+
+   Future<void> _goToEditLote() async {
+  if (_lote == null) return;
+
+  final result = await Navigator.pushNamed(
+    context,
+    '/lotes/edit',
+    arguments: _lote,
+  );
+
+  if (!mounted) return;
+
+  if (result is Lote) {
+    setState(() {
+      _lote = result;
+      _wasUpdated = true;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Lote actualizado')),
+    );
+  }
+}
+
+
+Future<void> _archiveLote() async {
+  if (_lote == null) return;
+
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: const Text('Archivar lote'),
+        content: const Text(
+          'Este lote dejará de estar activo para nuevas operaciones. '
+          'La información histórica se conservará.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Archivar'),
+          ),
+        ],
+      );
+    },
+  );
+
+  if (confirmed != true) return;
+
+  try {
+    await LotesRepository().updateEstadoLote(
+      loteId: _lote!.loteId,
+      estadoLote: 'ARCHIVADO',
+    );
+
+    if (!mounted) return;
+
+    setState(() {
+      _lote = Lote(
+        loteId: _lote!.loteId,
+        predioId: _lote!.predioId,
+        productorId: _lote!.productorId,
+        nombreLote: _lote!.nombreLote,
+        codigoLote: _lote!.codigoLote,
+        areaHectareas: _lote!.areaHectareas,
+        especieVegetalActual: _lote!.especieVegetalActual,
+        variedadActual: _lote!.variedadActual,
+        estadoLote: 'ARCHIVADO',
+        observaciones: _lote!.observaciones,
+        createdAt: _lote!.createdAt,
+        updatedAt: _lote!.updatedAt,
+      );
+      _wasUpdated = true;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Lote archivado correctamente')),
+    );
+  } catch (e) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('No fue posible archivar el lote: $e')),
+    );
+  }
+}
+
+Future<void> _changeEstadoLote(String nuevoEstado) async {
+  if (_lote == null) return;
+
+  final bool archivando = nuevoEstado == 'ARCHIVADO';
+
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: Text(archivando ? 'Archivar lote' : 'Activar lote'),
+        content: Text(
+          archivando
+              ? 'El lote dejará de estar disponible para nuevos eventos, pero conservará su historial.'
+              : 'El lote volverá a estar activo y permitirá nuevos eventos.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(archivando ? 'Archivar' : 'Activar'),
+          ),
+        ],
+      );
+    },
+  );
+
+  if (confirmed != true) return;
+
+  try {
+    await LotesRepository().updateEstadoLote(
+      loteId: _lote!.loteId,
+      estadoLote: nuevoEstado,
+    );
+
+    if (!mounted) return;
+
+    setState(() {
+      _lote = Lote(
+        loteId: _lote!.loteId,
+        predioId: _lote!.predioId,
+        productorId: _lote!.productorId,
+        nombreLote: _lote!.nombreLote,
+        codigoLote: _lote!.codigoLote,
+        areaHectareas: _lote!.areaHectareas,
+        especieVegetalActual: _lote!.especieVegetalActual,
+        variedadActual: _lote!.variedadActual,
+        estadoLote: nuevoEstado,
+        observaciones: _lote!.observaciones,
+        createdAt: _lote!.createdAt,
+        updatedAt: _lote!.updatedAt,
+      );
+      _wasUpdated = true;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          archivando
+              ? 'Lote archivado correctamente'
+              : 'Lote activado correctamente',
+        ),
+      ),
+    );
+  } catch (e) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('No fue posible actualizar el estado del lote: $e'),
+      ),
+    );
+  }
+}
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args is Lote) {
+      _lote = args;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const bg = Color(0xFFF7F9F5);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+    const primary = Color(0xFF2E7D32);
+
+    if (_lote == null) {
+      return Scaffold(
+        backgroundColor: bg,
+        appBar: AppBar(title: const Text('Detalle del lote')),
+        body: const Center(
+          child: Text('No se recibió información del lote'),
+        ),
+      );
+    }
+
+    final subtitle = _lote!.variedadActual != null && _lote!.variedadActual!.trim().isNotEmpty
+        ? '${_lote!.especieVegetalActual} · ${_lote!.variedadActual}'
+        : _lote!.especieVegetalActual;
+
+    return Scaffold(
+      backgroundColor: bg,
+      appBar: AppBar(
+  title: const Text('Detalle del lote'),
+  leading: IconButton(
+    icon: const Icon(Icons.arrow_back),
+    onPressed: () {
+      Navigator.pop(context, _wasUpdated ? _lote : null);
+    },
+  ),
+  actions: [
+  IconButton(
+    onPressed: _goToEditLote,
+    icon: const Icon(Icons.edit_outlined),
+    tooltip: 'Editar lote',
+  ),
+  IconButton(
+    onPressed: () => _changeEstadoLote(
+      _lote?.estadoLote == 'ACTIVO' ? 'ARCHIVADO' : 'ACTIVO',
+    ),
+    icon: Icon(
+      _lote?.estadoLote == 'ACTIVO'
+          ? Icons.archive_outlined
+          : Icons.unarchive_outlined,
+    ),
+    tooltip: _lote?.estadoLote == 'ACTIVO'
+        ? 'Archivar lote'
+        : 'Activar lote',
+  ),
+],
+),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+        children: [
+          Container(
+            padding: const EdgeInsets.all(18),
+            decoration: BoxDecoration(
+              color: primary,
+              borderRadius: BorderRadius.circular(24),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (_lote!.codigoLote != null && _lote!.codigoLote!.trim().isNotEmpty)
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFEAF4E7),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text(
+                      _lote!.codigoLote!,
+                      style: const TextStyle(
+                        color: primary,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                const SizedBox(height: 14),
+                Text(
+                  _lote!.nombreLote,
+                  style: const TextStyle(
+                    fontSize: 28,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '${_lote!.areaHectareas} ha · ${_lote!.estadoLote}',
+                  style: const TextStyle(
+                    fontSize: 15,
+                    color: Colors.white70,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  subtitle,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 18),
+          Row(
+            children: [
+              Expanded(
+                child: _ActionCard(
+                  icon: Icons.eco_outlined,
+                  title: 'Registrar evento',
+                  description: 'Inicia el registro del evento agrícola desde este lote.',
+                  onTap: _lote!.estadoLote == 'ACTIVO'
+    ? () {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Próximamente: registrar evento')),
+        );
+      }
+    : () {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('El lote está archivado y no permite nuevos eventos'),
+          ),
+        );
+      },
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _ActionCard(
+                  icon: Icons.history,
+                  title: 'Ver historial',
+                  description: 'Consulta la trazabilidad histórica de este lote.',
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Próximamente: historial del lote')),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 18),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(22),
+              border: Border.all(color: const Color(0xFFD7DED3)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Resumen del lote',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                    color: text,
+                  ),
+                ),
+                const SizedBox(height: 14),
+                Wrap(
+                  runSpacing: 10,
+                  spacing: 10,
+                  children: [
+                    _SummaryBox(label: 'Área', value: '${_lote!.areaHectareas} ha'),
+                    _SummaryBox(label: 'Estado', value: _lote!.estadoLote),
+                    _SummaryBox(label: 'Especie actual', value: _lote!.especieVegetalActual),
+                    _SummaryBox(
+                      label: 'Variedad',
+                      value: _lote!.variedadActual?.trim().isNotEmpty == true
+                          ? _lote!.variedadActual!
+                          : '-',
+                    ),
+                  ],
+                ),
+                if (_lote!.observaciones != null && _lote!.observaciones!.trim().isNotEmpty) ...[
+                  const SizedBox(height: 14),
+                  const Text(
+                    'Observaciones',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w700,
+                      color: text,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    _lote!.observaciones!,
+                    style: const TextStyle(
+                      color: softText,
+                      height: 1.45,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionCard extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String description;
+  final VoidCallback onTap;
+
+  const _ActionCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const border = Color(0xFFD7DED3);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+    const primary = Color(0xFF2E7D32);
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(22),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: border),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: primary),
+            const SizedBox(height: 12),
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w800,
+                color: text,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              description,
+              style: const TextStyle(
+                fontSize: 14,
+                color: softText,
+                height: 1.4,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryBox extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _SummaryBox({
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const bg = Color(0xFFF4F7F2);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+
+    return Container(
+      width: 155,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: const TextStyle(fontSize: 12, color: softText)),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: const TextStyle(
+              fontWeight: FontWeight.w700,
+              color: text,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/lotes/presentation/pages/lote_edit_page.dart
+++ b/mobile_app/lib/features/lotes/presentation/pages/lote_edit_page.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import '../../data/repositories/lotes_repository.dart';
+import '../../domain/models/lote.dart';
+import '../widgets/lote_form.dart';
+
+class LoteEditPage extends StatefulWidget {
+  const LoteEditPage({super.key});
+
+  @override
+  State<LoteEditPage> createState() => _LoteEditPageState();
+}
+
+class _LoteEditPageState extends State<LoteEditPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _repository = LotesRepository();
+
+  final _nombreController = TextEditingController();
+  final _codigoController = TextEditingController();
+  final _areaController = TextEditingController();
+  final _especieController = TextEditingController();
+  final _variedadController = TextEditingController();
+  final _observacionesController = TextEditingController();
+
+  bool _isSaving = false;
+  bool _isLoading = true;
+  Lote? _lote;
+
+  @override
+  void dispose() {
+    _nombreController.dispose();
+    _codigoController.dispose();
+    _areaController.dispose();
+    _especieController.dispose();
+    _variedadController.dispose();
+    _observacionesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_lote == null && _isLoading) {
+      _loadLote();
+    }
+  }
+
+  Future<void> _loadLote() async {
+    final args = ModalRoute.of(context)?.settings.arguments;
+
+    if (args is! Lote) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No se recibió el lote a editar')),
+      );
+      Navigator.pop(context);
+      return;
+    }
+
+    try {
+      final lote = await _repository.getLoteById(args.loteId);
+
+      if (lote == null) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Lote no encontrado')),
+        );
+        Navigator.pop(context);
+        return;
+      }
+
+      _lote = lote;
+      _nombreController.text = lote.nombreLote;
+      _codigoController.text = lote.codigoLote ?? '';
+      _areaController.text = '${lote.areaHectareas}';
+      _especieController.text = lote.especieVegetalActual;
+      _variedadController.text = lote.variedadActual ?? '';
+      _observacionesController.text = lote.observaciones ?? '';
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error al cargar lote: $e')),
+      );
+      Navigator.pop(context);
+      return;
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  Future<void> _updateLote() async {
+    if (!_formKey.currentState!.validate() || _lote == null) return;
+
+    setState(() => _isSaving = true);
+
+    try {
+      final area = double.parse(_areaController.text.trim().replaceAll(',', '.'));
+
+      final updatedLote = Lote(
+        loteId: _lote!.loteId,
+        predioId: _lote!.predioId,
+        productorId: _lote!.productorId,
+        nombreLote: _nombreController.text.trim(),
+        codigoLote: _codigoController.text.trim().isEmpty
+            ? null
+            : _codigoController.text.trim(),
+        areaHectareas: area,
+        especieVegetalActual: _especieController.text.trim(),
+        variedadActual: _variedadController.text.trim().isEmpty
+            ? null
+            : _variedadController.text.trim(),
+        estadoLote: _lote!.estadoLote,
+        observaciones: _observacionesController.text.trim().isEmpty
+            ? null
+            : _observacionesController.text.trim(),
+        createdAt: _lote!.createdAt,
+        updatedAt: _lote!.updatedAt,
+      );
+
+      await _repository.updateLote(updatedLote);
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Lote actualizado correctamente')),
+      );
+
+      Navigator.pop(context, updatedLote);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('No fue posible actualizar el lote: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const bg = Color(0xFFF7F9F5);
+
+    return Scaffold(
+      backgroundColor: bg,
+      appBar: AppBar(
+        title: const Text('Editar lote'),
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : LoteForm(
+              formKey: _formKey,
+              nombreController: _nombreController,
+              codigoController: _codigoController,
+              areaController: _areaController,
+              especieController: _especieController,
+              variedadController: _variedadController,
+              observacionesController: _observacionesController,
+              isSaving: _isSaving,
+              onSubmit: _updateLote,
+              submitLabel: 'Guardar cambios',
+            ),
+    );
+  }
+}

--- a/mobile_app/lib/features/lotes/presentation/widgets/lote_card.dart
+++ b/mobile_app/lib/features/lotes/presentation/widgets/lote_card.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import '../../domain/models/lote.dart';
+
+class LoteCard extends StatelessWidget {
+  final Lote lote;
+  final VoidCallback onTap;
+
+  const LoteCard({
+    super.key,
+    required this.lote,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const border = Color(0xFFD7DED3);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+    const softBg = Color(0xFFF4F7F2);
+    const primary = Color(0xFF2E7D32);
+
+    final subtitle = lote.variedadActual != null && lote.variedadActual!.trim().isNotEmpty
+        ? '${lote.especieVegetalActual} · ${lote.variedadActual}'
+        : lote.especieVegetalActual;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(color: border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            lote.nombreLote,
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+              color: text,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            subtitle,
+            style: const TextStyle(
+              fontSize: 14,
+              color: softText,
+            ),
+          ),
+          const SizedBox(height: 14),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: softBg,
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Área: ${lote.areaHectareas} ha',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w700,
+                      color: text,
+                    ),
+                  ),
+                ),
+                Container(
+  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+  decoration: BoxDecoration(
+    color: lote.estadoLote == 'ACTIVO'
+        ? const Color(0xFFEAF4E7)
+        : const Color(0xFFF3F4F6),
+    borderRadius: BorderRadius.circular(999),
+  ),
+  child: Text(
+    lote.estadoLote,
+    style: TextStyle(
+      color: lote.estadoLote == 'ACTIVO'
+          ? primary
+          : const Color(0xFF6B7280),
+      fontWeight: FontWeight.w700,
+    ),
+  ),
+),
+              ],
+            ),
+          ),
+          const SizedBox(height: 14),
+          SizedBox(
+            height: 44,
+            child: ElevatedButton(
+              onPressed: onTap,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: primary,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+              ),
+              child: const Text('Ver lote'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/lotes/presentation/widgets/lote_form.dart
+++ b/mobile_app/lib/features/lotes/presentation/widgets/lote_form.dart
@@ -1,0 +1,288 @@
+import 'package:flutter/material.dart';
+
+class LoteForm extends StatelessWidget {
+  final GlobalKey<FormState> formKey;
+  final TextEditingController nombreController;
+  final TextEditingController codigoController;
+  final TextEditingController areaController;
+  final TextEditingController especieController;
+  final TextEditingController variedadController;
+  final TextEditingController observacionesController;
+  final bool isSaving;
+  final VoidCallback onSubmit;
+  final String submitLabel;
+
+  const LoteForm({
+    super.key,
+    required this.formKey,
+    required this.nombreController,
+    required this.codigoController,
+    required this.areaController,
+    required this.especieController,
+    required this.variedadController,
+    required this.observacionesController,
+    required this.isSaving,
+    required this.onSubmit,
+    required this.submitLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const primary = Color(0xFF2E7D32);
+    const bg = Color(0xFFF7F9F5);
+    const cardBorder = Color(0xFFD7DED3);
+    const fieldBorder = Color(0xFFD6DDD2);
+    const titleColor = Color(0xFF1F2937);
+    const subtitleColor = Color(0xFF6B7280);
+
+    InputDecoration inputDecoration(String label) {
+      return InputDecoration(
+        labelText: label,
+        labelStyle: const TextStyle(
+          color: titleColor,
+          fontWeight: FontWeight.w600,
+        ),
+        filled: true,
+        fillColor: Colors.white,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 16,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: fieldBorder),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: fieldBorder),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: primary, width: 1.4),
+        ),
+      );
+    }
+
+    Widget sectionCard({
+      required String title,
+      required Widget child,
+    }) {
+      return Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: cardBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w800,
+                color: titleColor,
+              ),
+            ),
+            const SizedBox(height: 16),
+            child,
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      color: bg,
+      child: SafeArea(
+        child: Form(
+          key: formKey,
+          child: Column(
+            children: [
+              Expanded(
+                child: ListView(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF4F7F2),
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(color: cardBorder),
+                      ),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            width: 42,
+                            height: 42,
+                            decoration: BoxDecoration(
+                              color: const Color(0xFFEAF4E7),
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                            alignment: Alignment.center,
+                            child: const Text(
+                              '2',
+                              style: TextStyle(
+                                color: primary,
+                                fontWeight: FontWeight.w800,
+                                fontSize: 16,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 14),
+                          const Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  'Crear lote',
+                                  style: TextStyle(
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.w800,
+                                    color: titleColor,
+                                  ),
+                                ),
+                                SizedBox(height: 6),
+                                Text(
+                                  'Registra una unidad trazable dentro del predio seleccionado.',
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    color: subtitleColor,
+                                    height: 1.45,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    sectionCard(
+                      title: 'Datos del lote',
+                      child: Column(
+                        children: [
+                          TextFormField(
+                            controller: nombreController,
+                            decoration: inputDecoration('Nombre del lote'),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'El nombre del lote es obligatorio';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 14),
+                          TextFormField(
+                            controller: codigoController,
+                            decoration: inputDecoration('Código interno (opcional)'),
+                          ),
+                          const SizedBox(height: 14),
+                          TextFormField(
+                            controller: areaController,
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                            ),
+                            decoration: inputDecoration('Área (ha)'),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'El área es obligatoria';
+                              }
+                              final parsed = double.tryParse(
+                                value.trim().replaceAll(',', '.'),
+                              );
+                              if (parsed == null || parsed <= 0) {
+                                return 'Ingresa un área válida';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 14),
+                          TextFormField(
+                            controller: especieController,
+                            decoration: inputDecoration('Especie vegetal actual'),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'La especie vegetal es obligatoria';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 14),
+                          TextFormField(
+                            controller: variedadController,
+                            decoration: inputDecoration('Variedad actual (opcional)'),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    sectionCard(
+                      title: 'Notas',
+                      child: TextFormField(
+                        controller: observacionesController,
+                        maxLines: 4,
+                        decoration: inputDecoration('Observaciones (opcional)'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                color: bg,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: isSaving
+                            ? null
+                            : () => Navigator.of(context).pop(),
+                        style: OutlinedButton.styleFrom(
+                          minimumSize: const Size.fromHeight(54),
+                          side: const BorderSide(color: cardBorder),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          foregroundColor: primary,
+                        ),
+                        child: const Text('Cancelar'),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      flex: 2,
+                      child: ElevatedButton(
+                        onPressed: isSaving ? null : onSubmit,
+                        style: ElevatedButton.styleFrom(
+                          minimumSize: const Size.fromHeight(54),
+                          backgroundColor: primary,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                        ),
+                        child: isSaving
+                            ? const SizedBox(
+                                width: 22,
+                                height: 22,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
+                              )
+                            : Text(submitLabel),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/lotes/presentation/widgets/lotes_empty_state.dart
+++ b/mobile_app/lib/features/lotes/presentation/widgets/lotes_empty_state.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class LotesEmptyState extends StatelessWidget {
+  final VoidCallback onCreateLote;
+
+  const LotesEmptyState({
+    super.key,
+    required this.onCreateLote,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const border = Color(0xFFD7DED3);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+    const primary = Color(0xFF2E7D32);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(color: border),
+      ),
+      child: Column(
+        children: [
+          const Icon(
+            Icons.grid_view_rounded,
+            size: 42,
+            color: softText,
+          ),
+          const SizedBox(height: 12),
+          const Text(
+            'Aún no hay lotes registrados',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: text,
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Crea el primer lote dentro de este predio para empezar a organizar la trazabilidad.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 14,
+              color: softText,
+              height: 1.45,
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            height: 46,
+            child: ElevatedButton.icon(
+              onPressed: onCreateLote,
+              icon: const Icon(Icons.add),
+              label: const Text('Crear lote'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: primary,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/data/repositories/predios_repository.dart
+++ b/mobile_app/lib/features/predios/data/repositories/predios_repository.dart
@@ -1,0 +1,35 @@
+import '../../domain/models/predio.dart';
+import '../services/predios_service.dart';
+
+class PrediosRepository {
+  final PrediosService _service;
+
+  PrediosRepository({PrediosService? service})
+      : _service = service ?? PrediosService();
+
+  Future<List<Predio>> getPrediosByProductor(String productorId) {
+    return _service.getPrediosByProductor(productorId);
+  }
+
+  Future<void> createPredio(Predio predio) {
+    return _service.createPredio(predio);
+  }
+
+  Future<Predio?> getPredioById(String predioId) {
+    return _service.getPredioById(predioId);
+  }
+
+  Future<void> updatePredio(Predio predio) {
+    return _service.updatePredio(predio);
+  }
+
+  Future<void> updateEstadoPredio({
+  required String predioId,
+  required String estadoPredio,
+}) {
+  return _service.updateEstadoPredio(
+    predioId: predioId,
+    estadoPredio: estadoPredio,
+  );
+}
+}

--- a/mobile_app/lib/features/predios/data/services/predios_service.dart
+++ b/mobile_app/lib/features/predios/data/services/predios_service.dart
@@ -1,0 +1,69 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../domain/models/predio.dart';
+
+class PrediosService {
+  final FirebaseFirestore _firestore;
+
+  PrediosService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  Future<List<Predio>> getPrediosByProductor(String productorId) async {
+    final snapshot = await _firestore
+        .collection('predios')
+        .where('productorId', isEqualTo: productorId)
+        .orderBy('createdAt', descending: true)
+        .get();
+
+    return snapshot.docs.map((doc) => Predio.fromMap(doc.data())).toList();
+  }
+
+  Future<void> createPredio(Predio predio) async {
+    final docRef = _firestore.collection('predios').doc();
+
+    await docRef.set({
+      'predioId': docRef.id,
+      'productorId': predio.productorId,
+      'nombrePredio': predio.nombrePredio,
+      'departamento': predio.departamento,
+      'municipio': predio.municipio,
+      'vereda': predio.vereda,
+      'numeroRegistroICA': predio.numeroRegistroICA,
+      'areaRegistradaHa': predio.areaRegistradaHa,
+      'estadoPredio': predio.estadoPredio,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Future<Predio?> getPredioById(String predioId) async {
+    final doc = await _firestore.collection('predios').doc(predioId).get();
+
+    if (!doc.exists || doc.data() == null) {
+      return null;
+    }
+
+    return Predio.fromMap(doc.data()!);
+  }
+
+  Future<void> updatePredio(Predio predio) async {
+    await _firestore.collection('predios').doc(predio.predioId).update({
+      'nombrePredio': predio.nombrePredio,
+      'departamento': predio.departamento,
+      'municipio': predio.municipio,
+      'vereda': predio.vereda,
+      'numeroRegistroICA': predio.numeroRegistroICA,
+      'areaRegistradaHa': predio.areaRegistradaHa,
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Future<void> updateEstadoPredio({
+  required String predioId,
+  required String estadoPredio,
+}) async {
+  await _firestore.collection('predios').doc(predioId).update({
+    'estadoPredio': estadoPredio,
+    'updatedAt': FieldValue.serverTimestamp(),
+  });
+}
+}

--- a/mobile_app/lib/features/predios/domain/models/predio.dart
+++ b/mobile_app/lib/features/predios/domain/models/predio.dart
@@ -1,0 +1,67 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Predio {
+  final String predioId;
+  final String productorId;
+
+  final String nombrePredio;
+  final String departamento;
+  final String municipio;
+
+  final String? vereda;
+  final String? numeroRegistroICA;
+  final double? areaRegistradaHa;
+
+  final String estadoPredio;
+
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  Predio({
+    required this.predioId,
+    required this.productorId,
+    required this.nombrePredio,
+    required this.departamento,
+    required this.municipio,
+    this.vereda,
+    this.numeroRegistroICA,
+    this.areaRegistradaHa,
+    required this.estadoPredio,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'predioId': predioId,
+      'productorId': productorId,
+      'nombrePredio': nombrePredio,
+      'departamento': departamento,
+      'municipio': municipio,
+      'vereda': vereda,
+      'numeroRegistroICA': numeroRegistroICA,
+      'areaRegistradaHa': areaRegistradaHa,
+      'estadoPredio': estadoPredio,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  factory Predio.fromMap(Map<String, dynamic> map) {
+    return Predio(
+      predioId: map['predioId'] ?? '',
+      productorId: map['productorId'] ?? '',
+      nombrePredio: map['nombrePredio'] ?? '',
+      departamento: map['departamento'] ?? '',
+      municipio: map['municipio'] ?? '',
+      vereda: map['vereda'],
+      numeroRegistroICA: map['numeroRegistroICA'],
+      areaRegistradaHa: map['areaRegistradaHa'] != null
+          ? (map['areaRegistradaHa'] as num).toDouble()
+          : null,
+      estadoPredio: map['estadoPredio'] ?? 'ACTIVO',
+      createdAt: (map['createdAt'] as Timestamp?)?.toDate(),
+      updatedAt: (map['updatedAt'] as Timestamp?)?.toDate(),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/presentation/pages/predio_create_page.dart
+++ b/mobile_app/lib/features/predios/presentation/pages/predio_create_page.dart
@@ -1,0 +1,119 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import '../../data/repositories/predios_repository.dart';
+import '../../domain/models/predio.dart';
+import '../widgets/predio_form.dart';
+
+class PredioCreatePage extends StatefulWidget {
+  const PredioCreatePage({super.key});
+
+  @override
+  State<PredioCreatePage> createState() => _PredioCreatePageState();
+}
+
+class _PredioCreatePageState extends State<PredioCreatePage> {
+  final _formKey = GlobalKey<FormState>();
+  final _repository = PrediosRepository();
+
+  final _nombreController = TextEditingController();
+  final _departamentoController = TextEditingController();
+  final _municipioController = TextEditingController();
+  final _veredaController = TextEditingController();
+  final _areaController = TextEditingController();
+  final _numeroIcaController = TextEditingController();
+
+  bool _isSaving = false;
+
+  @override
+  void dispose() {
+    _nombreController.dispose();
+    _departamentoController.dispose();
+    _municipioController.dispose();
+    _veredaController.dispose();
+    _areaController.dispose();
+    _numeroIcaController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _savePredio() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No hay usuario autenticado')),
+      );
+      return;
+    }
+
+    setState(() => _isSaving = true);
+
+    try {
+      final areaText = _areaController.text.trim();
+      final area = areaText.isEmpty
+          ? null
+          : double.tryParse(areaText.replaceAll(',', '.'));
+
+      final predio = Predio(
+        predioId: '',
+        productorId: user.uid,
+        nombrePredio: _nombreController.text.trim(),
+        departamento: _departamentoController.text.trim(),
+        municipio: _municipioController.text.trim(),
+        vereda: _veredaController.text.trim().isEmpty
+            ? null
+            : _veredaController.text.trim(),
+        numeroRegistroICA: _numeroIcaController.text.trim().isEmpty
+            ? null
+            : _numeroIcaController.text.trim(),
+        areaRegistradaHa: area,
+        estadoPredio: 'ACTIVO',
+        createdAt: null,
+        updatedAt: null,
+      );
+
+      await _repository.createPredio(predio);
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Predio creado correctamente')),
+      );
+
+      Navigator.pop(context, true);
+    } catch (e) {
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('No fue posible crear el predio: $e'),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Crear predio'),
+      ),
+      body: PredioForm(
+        formKey: _formKey,
+        nombreController: _nombreController,
+        departamentoController: _departamentoController,
+        municipioController: _municipioController,
+        veredaController: _veredaController,
+        areaController: _areaController,
+        numeroIcaController: _numeroIcaController,
+        isSaving: _isSaving,
+        onSubmit: _savePredio,
+        submitLabel: 'Guardar predio',
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/presentation/pages/predio_detail_page.dart
+++ b/mobile_app/lib/features/predios/presentation/pages/predio_detail_page.dart
@@ -1,0 +1,328 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/features/predios/data/repositories/predios_repository.dart';
+import '../../../lotes/data/repositories/lotes_repository.dart';
+import '../../../lotes/domain/models/lote.dart';
+import '../../../lotes/presentation/widgets/lote_card.dart';
+import '../../../lotes/presentation/widgets/lotes_empty_state.dart';
+import '../../domain/models/predio.dart';
+import '../widgets/predio_info_card.dart';
+
+class PredioDetailPage extends StatefulWidget {
+  const PredioDetailPage({super.key});
+
+  @override
+  State<PredioDetailPage> createState() => _PredioDetailPageState();
+}
+
+class _PredioDetailPageState extends State<PredioDetailPage> {
+  final LotesRepository _lotesRepository = LotesRepository();
+
+  Predio? _predio;
+  bool _wasUpdated = false;
+  late Future<List<Lote>> _futureLotes;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    if (_predio == null) {
+      final args = ModalRoute.of(context)?.settings.arguments;
+
+      if (args is Predio) {
+        _predio = args;
+        _loadLotes();
+      }
+    }
+  }
+
+  void _loadLotes() {
+  if (_predio == null) return;
+  _futureLotes = _lotesRepository.getLotesByPredio(
+    predioId: _predio!.predioId,
+    productorId: _predio!.productorId,
+  );
+}
+  Future<void> _goToEditPredio() async {
+    if (_predio == null) return;
+
+    final result = await Navigator.pushNamed(
+      context,
+      '/predios/edit',
+      arguments: _predio,
+    );
+
+    if (!mounted) return;
+
+    if (result is Predio) {
+      setState(() {
+        _predio = result;
+        _wasUpdated = true;
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Predio actualizado')),
+      );
+    }
+  }
+
+  Future<void> _goToCreateLote() async {
+
+    if (_predio?.estadoPredio != 'ACTIVO') {
+  ScaffoldMessenger.of(context).showSnackBar(
+    const SnackBar(
+      content: Text('El predio está archivado y no permite crear nuevos lotes'),
+    ),
+  );
+  return;
+}
+    if (_predio == null) return;
+
+    final created = await Navigator.pushNamed(
+      context,
+      '/lotes/create',
+      arguments: _predio,
+    );
+
+    if (!mounted) return;
+
+    if (created == true) {
+      setState(() {
+        _loadLotes();
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Lote creado correctamente')),
+      );
+    }
+  }
+
+  Future<void> _goToLoteDetail(Lote lote) async {
+  final result = await Navigator.pushNamed(
+    context,
+    '/lotes/detail',
+    arguments: lote,
+  );
+
+  if (!mounted) return;
+
+  if (result is Lote) {
+    setState(() {
+      _loadLotes();
+    });
+  }
+}
+
+Future<void> _changeEstadoPredio(String nuevoEstado) async {
+  if (_predio == null) return;
+
+  final bool archivando = nuevoEstado == 'ARCHIVADO';
+
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: Text(archivando ? 'Archivar predio' : 'Activar predio'),
+        content: Text(
+          archivando
+              ? 'El predio dejará de estar disponible para nuevas operaciones, pero conservará su historial.'
+              : 'El predio volverá a estar activo y permitirá nuevas operaciones.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(archivando ? 'Archivar' : 'Activar'),
+          ),
+        ],
+      );
+    },
+  );
+
+  if (confirmed != true) return;
+
+  try {
+    await _lotesRepository; // no quitar si ya existe el repo arriba
+    await PrediosRepository().updateEstadoPredio(
+      predioId: _predio!.predioId,
+      estadoPredio: nuevoEstado,
+    );
+
+    if (!mounted) return;
+
+    setState(() {
+      _predio = Predio(
+        predioId: _predio!.predioId,
+        productorId: _predio!.productorId,
+        nombrePredio: _predio!.nombrePredio,
+        numeroRegistroICA: _predio!.numeroRegistroICA,
+        departamento: _predio!.departamento,
+        municipio: _predio!.municipio,
+        vereda: _predio!.vereda,
+        areaRegistradaHa: _predio!.areaRegistradaHa,
+        estadoPredio: nuevoEstado,
+        createdAt: _predio!.createdAt,
+        updatedAt: _predio!.updatedAt,
+      );
+      _wasUpdated = true;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          archivando
+              ? 'Predio archivado correctamente'
+              : 'Predio activado correctamente',
+        ),
+      ),
+    );
+  } catch (e) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('No fue posible actualizar el estado del predio: $e'),
+      ),
+    );
+  }
+}
+
+  @override
+  Widget build(BuildContext context) {
+    const bg = Color(0xFFF7F9F5);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+
+    if (_predio == null) {
+      return Scaffold(
+        backgroundColor: bg,
+        appBar: AppBar(title: const Text('Detalle de predio')),
+        body: const Center(
+          child: Text('No se recibió información del predio'),
+        ),
+      );
+    }
+
+    return PopScope(
+      canPop: true,
+      child: Scaffold(
+        backgroundColor: bg,
+        appBar: AppBar(
+          title: const Text('Detalle de predio'),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () {
+              Navigator.pop(context, _wasUpdated ? _predio : null);
+            },
+          ),
+          actions: [
+  IconButton(
+    onPressed: _goToEditPredio,
+    icon: const Icon(Icons.edit_outlined),
+    tooltip: 'Editar predio',
+  ),
+  IconButton(
+    onPressed: () => _changeEstadoPredio(
+      _predio?.estadoPredio == 'ACTIVO' ? 'ARCHIVADO' : 'ACTIVO',
+    ),
+    icon: Icon(
+      _predio?.estadoPredio == 'ACTIVO'
+          ? Icons.archive_outlined
+          : Icons.unarchive_outlined,
+    ),
+    tooltip: _predio?.estadoPredio == 'ACTIVO'
+        ? 'Archivar predio'
+        : 'Activar predio',
+  ),
+],
+        ),
+        body: ListView(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+          children: [
+            const Text(
+              'Información general',
+              style: TextStyle(fontSize: 14, color: softText),
+            ),
+            const SizedBox(height: 10),
+            PredioInfoCard(predio: _predio!),
+            const SizedBox(height: 20),
+            const Text(
+              'Lotes del predio',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w800,
+                color: text,
+              ),
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              'Aquí verás las unidades productivas asociadas a este predio.',
+              style: TextStyle(fontSize: 14, color: softText),
+            ),
+            const SizedBox(height: 14),
+            FutureBuilder<List<Lote>>(
+              future: _futureLotes,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(24),
+                      child: CircularProgressIndicator(),
+                    ),
+                  );
+                }
+
+                if (snapshot.hasError) {
+                  return const Center(
+                    child: Text('Error al cargar lotes'),
+                  );
+                }
+
+                final lotes = snapshot.data ?? [];
+
+                if (lotes.isEmpty) {
+                  return LotesEmptyState(
+                    onCreateLote: _goToCreateLote,
+                  );
+                }
+
+                return Column(
+                  children: lotes
+                      .map(
+                        (lote) => LoteCard(
+                          lote: lote,
+                          onTap: () => _goToLoteDetail(lote),
+                        ),
+                      )
+                      .toList(),
+                );
+              },
+            ),
+          ],
+        ),
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+        floatingActionButton: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: SizedBox(
+            width: double.infinity,
+            height: 54,
+            child: FloatingActionButton.extended(
+              onPressed: _predio?.estadoPredio == 'ACTIVO' ? _goToCreateLote : null,
+              backgroundColor: const Color(0xFF2E7D32),
+              foregroundColor: Colors.white,
+              icon: const Icon(Icons.add),
+              label: const Text(
+                'Crear lote',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/presentation/pages/predio_edit_page.dart
+++ b/mobile_app/lib/features/predios/presentation/pages/predio_edit_page.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import '../../data/repositories/predios_repository.dart';
+import '../../domain/models/predio.dart';
+import '../widgets/predio_form.dart';
+
+class PredioEditPage extends StatefulWidget {
+  const PredioEditPage({super.key});
+
+  @override
+  State<PredioEditPage> createState() => _PredioEditPageState();
+}
+
+class _PredioEditPageState extends State<PredioEditPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _repository = PrediosRepository();
+
+  final _nombreController = TextEditingController();
+  final _departamentoController = TextEditingController();
+  final _municipioController = TextEditingController();
+  final _veredaController = TextEditingController();
+  final _areaController = TextEditingController();
+  final _numeroIcaController = TextEditingController();
+
+  bool _isSaving = false;
+  bool _isLoading = true;
+  Predio? _predio;
+
+  @override
+  void dispose() {
+    _nombreController.dispose();
+    _departamentoController.dispose();
+    _municipioController.dispose();
+    _veredaController.dispose();
+    _areaController.dispose();
+    _numeroIcaController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_predio == null && _isLoading) {
+      _loadPredio();
+    }
+  }
+
+  Future<void> _loadPredio() async {
+    final args = ModalRoute.of(context)?.settings.arguments;
+
+    if (args is! Predio) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No se recibió el predio a editar')),
+      );
+      Navigator.pop(context);
+      return;
+    }
+
+    try {
+      final predio = await _repository.getPredioById(args.predioId);
+
+      if (predio == null) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Predio no encontrado')),
+        );
+        Navigator.pop(context);
+        return;
+      }
+
+      _predio = predio;
+      _nombreController.text = predio.nombrePredio;
+      _departamentoController.text = predio.departamento;
+      _municipioController.text = predio.municipio;
+      _veredaController.text = predio.vereda ?? '';
+      _areaController.text =
+          predio.areaRegistradaHa != null ? '${predio.areaRegistradaHa}' : '';
+      _numeroIcaController.text = predio.numeroRegistroICA ?? '';
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error al cargar predio: $e')),
+      );
+      Navigator.pop(context);
+      return;
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  Future<void> _updatePredio() async {
+    if (!_formKey.currentState!.validate() || _predio == null) return;
+
+    setState(() => _isSaving = true);
+
+    try {
+      final areaText = _areaController.text.trim();
+      final area = areaText.isEmpty
+          ? null
+          : double.tryParse(areaText.replaceAll(',', '.'));
+
+      final updatedPredio = Predio(
+        predioId: _predio!.predioId,
+        productorId: _predio!.productorId,
+        nombrePredio: _nombreController.text.trim(),
+        departamento: _departamentoController.text.trim(),
+        municipio: _municipioController.text.trim(),
+        vereda: _veredaController.text.trim().isEmpty
+            ? null
+            : _veredaController.text.trim(),
+        numeroRegistroICA: _numeroIcaController.text.trim().isEmpty
+            ? null
+            : _numeroIcaController.text.trim(),
+        areaRegistradaHa: area,
+        estadoPredio: _predio!.estadoPredio,
+        createdAt: _predio!.createdAt,
+        updatedAt: _predio!.updatedAt,
+      );
+
+      await _repository.updatePredio(updatedPredio);
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Predio actualizado correctamente')),
+      );
+
+      Navigator.pop(context, updatedPredio);
+    } catch (e) {
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('No fue posible actualizar el predio: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const bg = Color(0xFFF7F9F5);
+
+    return Scaffold(
+      backgroundColor: bg,
+      appBar: AppBar(
+        title: const Text('Editar predio'),
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : PredioForm(
+              formKey: _formKey,
+              nombreController: _nombreController,
+              departamentoController: _departamentoController,
+              municipioController: _municipioController,
+              veredaController: _veredaController,
+              areaController: _areaController,
+              numeroIcaController: _numeroIcaController,
+              isSaving: _isSaving,
+              onSubmit: _updatePredio,
+              submitLabel: 'Guardar cambios',
+            ),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/presentation/pages/predios_list_page.dart
+++ b/mobile_app/lib/features/predios/presentation/pages/predios_list_page.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../../data/repositories/predios_repository.dart';
+import '../../domain/models/predio.dart';
+import '../widgets/predio_card.dart';
+import '../widgets/predios_empty_state.dart';
+
+class PrediosListPage extends StatefulWidget {
+  const PrediosListPage({super.key});
+
+  @override
+  State<PrediosListPage> createState() => _PrediosListPageState();
+}
+
+class _PrediosListPageState extends State<PrediosListPage> {
+  final PrediosRepository _repository = PrediosRepository();
+
+  late Future<List<Predio>> _futurePredios;
+
+  List<Predio> _allPredios = [];
+  List<Predio> _filteredPredios = [];
+
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPredios();
+    _searchController.addListener(_onSearchChanged);
+  }
+
+  void _loadPredios() {
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user == null) {
+      throw Exception('Usuario no autenticado');
+    }
+
+    _futurePredios = _repository.getPrediosByProductor(user.uid);
+  }
+
+  void _onSearchChanged() {
+    final query = _searchController.text.toLowerCase();
+
+    setState(() {
+      _filteredPredios = _allPredios
+          .where((p) =>
+              p.nombrePredio.toLowerCase().contains(query))
+          .toList();
+    });
+  }
+
+  Future<void> _goToCreatePredio() async {
+    final created =
+        await Navigator.pushNamed(context, '/predios/create');
+
+    if (created == true) {
+      setState(() {
+        _loadPredios();
+      });
+    }
+  }
+
+  Future<void> _goToPredioDetail(Predio predio) async {
+  final result = await Navigator.pushNamed(
+    context,
+    '/predios/detail',
+    arguments: predio,
+  );
+
+  if (!mounted) return;
+
+  if (result is Predio) {
+    setState(() {
+      final index =
+          _allPredios.indexWhere((item) => item.predioId == result.predioId);
+
+      if (index != -1) {
+        _allPredios[index] = result;
+      }
+
+      final filteredIndex =
+          _filteredPredios.indexWhere((item) => item.predioId == result.predioId);
+
+      if (filteredIndex != -1) {
+        _filteredPredios[filteredIndex] = result;
+      }
+    });
+  }
+}
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const bg = Color(0xFFF7F9F5);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+    const border = Color(0xFFD7DED3);
+
+    return Scaffold(
+      backgroundColor: bg,
+      appBar: AppBar(
+        title: const Text('Predios'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            /// Subtítulo
+            const Text(
+              'Fincas registradas',
+              style: TextStyle(
+                fontSize: 14,
+                color: softText,
+              ),
+            ),
+
+            const SizedBox(height: 14),
+
+            /// Buscador
+            TextField(
+              controller: _searchController,
+              decoration: InputDecoration(
+                hintText: 'Buscar predio',
+                prefixIcon: const Icon(Icons.search),
+                filled: true,
+                fillColor: Colors.white,
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 14,
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(16),
+                  borderSide: const BorderSide(color: border),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(16),
+                  borderSide: const BorderSide(color: border),
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            /// Lista
+            Expanded(
+              child: FutureBuilder<List<Predio>>(
+                future: _futurePredios,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState ==
+                      ConnectionState.waiting) {
+                    return const Center(
+                      child: CircularProgressIndicator(),
+                    );
+                  }
+
+                  if (snapshot.hasError) {
+                    return const Center(
+                      child: Text('Error al cargar predios'),
+                    );
+                  }
+
+                  _allPredios = snapshot.data ?? [];
+
+                  /// Si no hay búsqueda, usar todos
+                  if (_searchController.text.isEmpty) {
+                    _filteredPredios = _allPredios;
+                  }
+
+                  if (_filteredPredios.isEmpty) {
+                    return PrediosEmptyState(
+                      onCreate: _goToCreatePredio,
+                    );
+                  }
+
+                  return ListView.builder(
+                    itemCount: _filteredPredios.length,
+                    itemBuilder: (context, index) {
+                      final predio = _filteredPredios[index];
+
+                      return PredioCard(
+  predio: predio,
+  onTap: () => _goToPredioDetail(predio),
+);
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+
+      /// FAB
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: SizedBox(
+          width: double.infinity,
+          height: 54,
+          child: FloatingActionButton.extended(
+            onPressed: _goToCreatePredio,
+            backgroundColor: const Color(0xFF2E7D32),
+            foregroundColor: Colors.white,
+            icon: const Icon(Icons.add),
+            label: const Text(
+              'Crear predio',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/presentation/widgets/lotes_empty_state.dart
+++ b/mobile_app/lib/features/predios/presentation/widgets/lotes_empty_state.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class LotesEmptyState extends StatelessWidget {
+  final VoidCallback onCreateLote;
+
+  const LotesEmptyState({
+    super.key,
+    required this.onCreateLote,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const border = Color(0xFFD7DED3);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+    const primary = Color(0xFF2E7D32);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(color: border),
+      ),
+      child: Column(
+        children: [
+          const Icon(
+            Icons.grid_view_rounded,
+            size: 42,
+            color: softText,
+          ),
+          const SizedBox(height: 12),
+          const Text(
+            'Aún no hay lotes registrados',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: text,
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Crea el primer lote dentro de este predio para empezar a organizar la trazabilidad.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 14,
+              color: softText,
+              height: 1.45,
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            height: 46,
+            child: ElevatedButton.icon(
+              onPressed: onCreateLote,
+              icon: const Icon(Icons.add),
+              label: const Text('Crear lote'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: primary,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/presentation/widgets/predio_card.dart
+++ b/mobile_app/lib/features/predios/presentation/widgets/predio_card.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import '../../domain/models/predio.dart';
+
+class PredioCard extends StatelessWidget {
+  final Predio predio;
+  final VoidCallback onTap;
+
+  const PredioCard({
+    super.key,
+    required this.predio,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const primary = Color(0xFF2E7D32);
+    const border = Color(0xFFD7DED3);
+    const softBg = Color(0xFFF4F7F2);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 14),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(color: border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          /// Nombre
+          Text(
+            predio.nombrePredio,
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+              color: text,
+            ),
+          ),
+
+          const SizedBox(height: 6),
+
+          /// Ubicación
+          Text(
+            '${predio.municipio}${predio.vereda != null ? " · ${predio.vereda}" : ""}',
+            style: const TextStyle(
+              fontSize: 14,
+              color: softText,
+            ),
+          ),
+
+          const SizedBox(height: 14),
+
+          /// Datos productivos
+          Row(
+            children: [
+              Expanded(
+                child: _InfoBox(
+                  label: 'Área total',
+                  value: predio.areaRegistradaHa != null
+                      ? '${predio.areaRegistradaHa} ha'
+                      : '-',
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: _InfoBox(
+                  label: 'Registro ICA',
+                  value: predio.numeroRegistroICA ?? '-',
+                ),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 16),
+
+          /// Acción principal
+          SizedBox(
+            height: 44,
+            child: ElevatedButton(
+              onPressed: onTap,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: primary,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+              ),
+              child: const Text('Ver predio'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoBox extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _InfoBox({
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const bg = Color(0xFFF4F7F2);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              color: softText,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: text,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/presentation/widgets/predio_form.dart
+++ b/mobile_app/lib/features/predios/presentation/widgets/predio_form.dart
@@ -1,0 +1,344 @@
+import 'package:flutter/material.dart';
+
+class PredioForm extends StatelessWidget {
+  final GlobalKey<FormState> formKey;
+  final TextEditingController nombreController;
+  final TextEditingController departamentoController;
+  final TextEditingController municipioController;
+  final TextEditingController veredaController;
+  final TextEditingController areaController;
+  final TextEditingController numeroIcaController;
+  final bool isSaving;
+  final VoidCallback onSubmit;
+  final String submitLabel;
+
+  const PredioForm({
+    super.key,
+    required this.formKey,
+    required this.nombreController,
+    required this.departamentoController,
+    required this.municipioController,
+    required this.veredaController,
+    required this.areaController,
+    required this.numeroIcaController,
+    required this.isSaving,
+    required this.onSubmit,
+    required this.submitLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const primary = Color(0xFF2E7D32);
+    const bg = Color(0xFFF7F9F5);
+    const cardBorder = Color(0xFFD7DED3);
+    const fieldBorder = Color(0xFFD6DDD2);
+    const titleColor = Color(0xFF1F2937);
+    const subtitleColor = Color(0xFF6B7280);
+
+    InputDecoration inputDecoration(String label) {
+      return InputDecoration(
+        labelText: label,
+        labelStyle: const TextStyle(
+          color: titleColor,
+          fontWeight: FontWeight.w600,
+        ),
+        filled: true,
+        fillColor: Colors.white,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 16,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: fieldBorder),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: fieldBorder),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: primary, width: 1.4),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: Colors.redAccent),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+        ),
+      );
+    }
+
+    Widget sectionCard({
+      required String title,
+      required Widget child,
+    }) {
+      return Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: cardBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w800,
+                color: titleColor,
+              ),
+            ),
+            const SizedBox(height: 16),
+            child,
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      color: bg,
+      child: SafeArea(
+        child: Form(
+          key: formKey,
+          child: Column(
+            children: [
+              Expanded(
+                child: ListView(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF4F7F2),
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(color: cardBorder),
+                      ),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            width: 42,
+                            height: 42,
+                            decoration: BoxDecoration(
+                              color: const Color(0xFFEAF4E7),
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                            alignment: Alignment.center,
+                            child: const Text(
+                              '1',
+                              style: TextStyle(
+                                color: primary,
+                                fontWeight: FontWeight.w800,
+                                fontSize: 16,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 14),
+                          const Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  'Primer paso',
+                                  style: TextStyle(
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.w800,
+                                    color: titleColor,
+                                  ),
+                                ),
+                                SizedBox(height: 6),
+                                Text(
+                                  'Cree la finca o predio antes de registrar sus lotes.',
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    color: subtitleColor,
+                                    height: 1.45,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    sectionCard(
+                      title: 'Datos del predio',
+                      child: Column(
+                        children: [
+                          TextFormField(
+                            controller: nombreController,
+                            textInputAction: TextInputAction.next,
+                            decoration: inputDecoration('Nombre del predio'),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'El nombre del predio es obligatorio';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 14),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: TextFormField(
+                                  controller: departamentoController,
+                                  textInputAction: TextInputAction.next,
+                                  decoration:
+                                      inputDecoration('Departamento'),
+                                  validator: (value) {
+                                    if (value == null ||
+                                        value.trim().isEmpty) {
+                                      return 'Requerido';
+                                    }
+                                    return null;
+                                  },
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: TextFormField(
+                                  controller: municipioController,
+                                  textInputAction: TextInputAction.next,
+                                  decoration: inputDecoration('Municipio'),
+                                  validator: (value) {
+                                    if (value == null ||
+                                        value.trim().isEmpty) {
+                                      return 'Requerido';
+                                    }
+                                    return null;
+                                  },
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 14),
+                          TextFormField(
+                            controller: veredaController,
+                            textInputAction: TextInputAction.next,
+                            decoration: inputDecoration('Vereda (opcional)'),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    sectionCard(
+                      title: 'Datos productivos',
+                      child: Column(
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: TextFormField(
+                                  controller: areaController,
+                                  keyboardType:
+                                      const TextInputType.numberWithOptions(
+                                    decimal: true,
+                                  ),
+                                  textInputAction: TextInputAction.next,
+                                  decoration:
+                                      inputDecoration('Área total (ha)'),
+                                  validator: (value) {
+                                    if (value == null ||
+                                        value.trim().isEmpty) {
+                                      return null;
+                                    }
+                                    final parsed = double.tryParse(
+                                      value.trim().replaceAll(',', '.'),
+                                    );
+                                    if (parsed == null || parsed < 0) {
+                                      return 'Área inválida';
+                                    }
+                                    return null;
+                                  },
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: TextFormField(
+                                  controller: numeroIcaController,
+                                  textInputAction: TextInputAction.done,
+                                  decoration: inputDecoration(
+                                    'Número de registro ICA',
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                decoration: const BoxDecoration(
+                  color: bg,
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: isSaving
+                            ? null
+                            : () => Navigator.of(context).pop(),
+                        style: OutlinedButton.styleFrom(
+                          minimumSize: const Size.fromHeight(54),
+                          side: const BorderSide(color: cardBorder),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          foregroundColor: primary,
+                          textStyle: const TextStyle(
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        child: const Text('Cancelar'),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      flex: 2,
+                      child: ElevatedButton(
+                        onPressed: isSaving ? null : onSubmit,
+                        style: ElevatedButton.styleFrom(
+                          minimumSize: const Size.fromHeight(54),
+                          backgroundColor: primary,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          textStyle: const TextStyle(
+                            fontWeight: FontWeight.w700,
+                            fontSize: 16,
+                          ),
+                        ),
+                        child: isSaving
+                            ? const SizedBox(
+                                width: 22,
+                                height: 22,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
+                              )
+                            : Text(submitLabel),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/presentation/widgets/predio_info_card.dart
+++ b/mobile_app/lib/features/predios/presentation/widgets/predio_info_card.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import '../../domain/models/predio.dart';
+
+class PredioInfoCard extends StatelessWidget {
+  final Predio predio;
+
+  const PredioInfoCard({
+    super.key,
+    required this.predio,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const border = Color(0xFFD7DED3);
+    const softBg = Color(0xFFF4F7F2);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+
+    String ubicacion = predio.vereda != null && predio.vereda!.trim().isNotEmpty
+        ? '${predio.municipio}, ${predio.departamento} · ${predio.vereda}'
+        : '${predio.municipio}, ${predio.departamento}';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(color: border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            predio.nombrePredio,
+            style: const TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.w800,
+              color: text,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            ubicacion,
+            style: const TextStyle(
+              fontSize: 14,
+              color: softText,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: predio.estadoPredio == 'ACTIVO'
+                  ? const Color(0xFFEAF4E7)
+                  : const Color(0xFFF3F4F6),
+              borderRadius: BorderRadius.circular(999),
+            ),
+            child: Text(
+              predio.estadoPredio,
+              style: TextStyle(
+                color: predio.estadoPredio == 'ACTIVO'
+                    ? const Color(0xFF2E7D32)
+                    : const Color(0xFF6B7280),
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: _InfoBox(
+                  label: 'Área total',
+                  value: predio.areaRegistradaHa != null
+                      ? '${predio.areaRegistradaHa} ha'
+                      : '-',
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: _InfoBox(
+                  label: 'Registro ICA',
+                  value: predio.numeroRegistroICA?.trim().isNotEmpty == true
+                      ? predio.numeroRegistroICA!
+                      : '-',
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoBox extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _InfoBox({
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const softBg = Color(0xFFF4F7F2);
+    const text = Color(0xFF1F2937);
+    const softText = Color(0xFF6B7280);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: softBg,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              color: softText,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: text,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/predios/presentation/widgets/predios_empty_state.dart
+++ b/mobile_app/lib/features/predios/presentation/widgets/predios_empty_state.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class PrediosEmptyState extends StatelessWidget {
+  final VoidCallback onCreate;
+
+  const PrediosEmptyState({super.key, required this.onCreate});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Icon(Icons.landscape, size: 64, color: Colors.grey),
+        const SizedBox(height: 16),
+        const Text(
+          'Aún no tienes predios registrados',
+          style: TextStyle(fontSize: 16),
+        ),
+        const SizedBox(height: 12),
+        ElevatedButton(
+          onPressed: onCreate,
+          child: const Text('Crear predio'),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -1,6 +1,13 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:mobile_app/features/predios/presentation/pages/predio_create_page.dart';
+import 'package:mobile_app/features/predios/presentation/pages/predios_list_page.dart';
+import 'features/predios/presentation/pages/predio_edit_page.dart';
 import 'features/auth/presentation/pages/auth_gate_page.dart';
+import 'features/predios/presentation/pages/predio_detail_page.dart';
+import 'features/lotes/presentation/pages/lote_create_page.dart';
+import 'features/lotes/presentation/pages/lote_detail_page.dart';
+import 'features/lotes/presentation/pages/lote_edit_page.dart';
 import 'features/auth/presentation/pages/login_page.dart';
 import 'features/auth/presentation/pages/register_page.dart';
 import 'features/home/presentation/pages/dashboard_placeholder_page.dart';
@@ -36,6 +43,13 @@ class AgroTrackApp extends StatelessWidget {
         '/login': (context) => const LoginPage(),
         '/register': (context) => const RegisterPage(),
         '/dashboard': (context) => const DashboardPlaceholderPage(),
+        '/predios': (context) => const PrediosListPage(),
+        '/predios/create': (context) => const PredioCreatePage(),
+        '/predios/edit': (context) => const PredioEditPage(),
+        '/predios/detail': (context) => const PredioDetailPage(),
+        '/lotes/create': (context) => const LoteCreatePage(),
+        '/lotes/detail': (context) => const LoteDetailPage(),        
+        '/lotes/edit': (context) => const LoteEditPage(),
       },
     );
   }


### PR DESCRIPTION
**Este PR implementa el módulo completo de gestión de estructura productiva: Predios y Lotes, permitiendo al productor agrícola crear, visualizar, editar y navegar su estructura operativa bajo el modelo:****

### Productor → Predio → Lote

Incluye:
Listado de predios del usuario autenticado
Búsqueda simple de predios por nombre
Creación y edición de predio
Visualización de detalle de predio
Creación de lote asociado a predio
Visualización de detalle de lote
Edición de lote
Cambio de estado reversible (ACTIVO / ARCHIVADO) para predios y lotes
Bloqueo de operaciones cuando la unidad productiva está archivada
Persistencia en Firestore con validación por productorId

Este PR deja cerrada la estructura productiva base necesaria para la futura implementación del módulo de eventos agrícolas y trazabilidad.

🔗 Cierre de issues

Closes #5
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16
Closes #33Closes #34

